### PR TITLE
docs: use patched Erigon v3.3.0 image for Linea from-scratch sync

### DIFF
--- a/docs/network/how-to/run-a-node/erigon.mdx
+++ b/docs/network/how-to/run-a-node/erigon.mdx
@@ -25,10 +25,24 @@ layer client, [Maru](./maru.mdx), for the node to function.
 
 :::warning Current Erigon support
 
-Erigon support for current Linea is merged upstream in
-[erigontech/erigon#20298](https://github.com/erigontech/erigon/pull/20298) and is included in the
-Erigon `v3.5` milestone. Until an official `v3.5` or later Docker image is published, build a local
-image from the #20298 merge commit and use that image in the compose file.
+Stock Erigon does not sync current Linea from scratch. Tested against
+`erigontech/erigon:v3.5.0` with `--externalcl` + Maru, it hangs at block 0
+([erigontech/erigon#22081](https://github.com/erigontech/erigon/issues/22081)),
+and earlier versions hit `[EIP-7002] Syscall failure: Empty Code` at the Fusaka
+fork because Linea's genesis allocates no code at the withdrawal/consolidation
+contract addresses ([erigontech/erigon#18160](https://github.com/erigontech/erigon/issues/18160)).
+
+The example Docker Compose file therefore references a patched Erigon image,
+`linea-erigon:v3.3.0-linea-patched`, which applies three fixes on top of Erigon `v3.3.0`:
+
+- `sentryMcDisableBlockDownload = false` (enables EL-driven bootstrap from genesis)
+- EIP-7002 empty-code syscall returns `nil` instead of erroring (Fusaka fix)
+- EIP-7251 empty-code syscall returns `nil` instead of erroring (Fusaka fix)
+
+This image is not published to a registry — you build it locally from the Dockerfile
+shipped in the monorepo at
+[`docs/getting-started/linea-mainnet/erigon-linea/`](https://github.com/LFDT-Lineth/lineth-monorepo/tree/main/docs/getting-started/linea-mainnet/erigon-linea)
+(see Step 1 below).
 
 :::
 
@@ -36,19 +50,26 @@ image from the #20298 merge commit and use that image in the compose file.
 
 - [Docker](https://docker.com/products/docker-desktop/)
 
-### Step 1. Build an Erigon image from the Linea merge commit
+### Step 1. Build the patched Erigon image
 
-Build the Docker image from the #20298 merge commit:
+Clone the Linea monorepo (if you haven't already) and build the patched Erigon image from the
+Dockerfile shipped in the repo:
 
 ```bash
-git clone https://github.com/erigontech/erigon.git
-cd erigon
-git checkout 34ac22904b0de1b14cf054a7cf2c0d02461215f3
-docker build -t erigon-linea:pr-20298 .
+git clone https://github.com/LFDT-Lineth/lineth-monorepo.git
+cd lineth-monorepo/docs/getting-started/linea-mainnet/erigon-linea
+make build
 ```
 
-After an official Erigon `v3.5` or later image is published, you can skip this step and use the
-official release image in the compose file instead.
+This builds `linea-erigon:v3.3.0-linea-patched` and loads it into your local Docker daemon. The
+getting-started compose file references this image name, so after building you can start the
+node directly.
+
+On Apple Silicon (arm64), build for arm64 so the image runs natively:
+
+```bash
+make build PLATFORM=linux/arm64
+```
 
 ### Step 2. Download the Linea node example config
 
@@ -60,16 +81,8 @@ configuration. The same directory contains the Geth genesis file that Erigon sho
   
   Download or clone the
   [`docs/getting-started/linea-mainnet`](https://github.com/LFDT-Lineth/lineth-monorepo/tree/main/docs/getting-started/linea-mainnet)
-  directory from the Linea monorepo.
-
-  Use the
-  [`geth/geth-genesis.json`](https://github.com/LFDT-Lineth/lineth-monorepo/blob/main/docs/getting-started/linea-mainnet/geth/geth-genesis.json)
-  file as the Erigon genesis file. The Erigon services in the example compose file expect
-  `./genesis.json`, so copy the Geth genesis file to that name:
-
-  ```bash
-  cp geth/geth-genesis.json genesis.json
-  ```
+  directory from the Linea monorepo. The Erigon services in the compose file already reference
+  the patched image and mount the Geth genesis file directly, so no manual edits are required.
 
   :::note[bootnodes]
   You can choose from a range of bootnodes for Linea Mainnet. The Docker Compose file uses all
@@ -83,75 +96,31 @@ configuration. The same directory contains the Geth genesis file that Erigon sho
   
   Download or clone the
   [`docs/getting-started/linea-sepolia`](https://github.com/LFDT-Lineth/lineth-monorepo/tree/main/docs/getting-started/linea-sepolia)
-  directory from the Linea monorepo.
-
-  Use the
-  [`geth/geth-genesis.json`](https://github.com/LFDT-Lineth/lineth-monorepo/blob/main/docs/getting-started/linea-sepolia/geth/geth-genesis.json)
-  file as the Erigon genesis file. The Erigon services in the example compose file expect
-  `./genesis.json`, so copy the Geth genesis file to that name:
-
-  ```bash
-  cp geth/geth-genesis.json genesis.json
-  ```
+  directory from the Linea monorepo. The Erigon services in the compose file already reference
+  the patched image and mount the Geth genesis file directly, so no manual edits are required.
 
   </TabItem>
 </Tabs>
 
-### Step 3. Update the Erigon services in Docker Compose
+### Step 3. Start the Erigon node
 
-The monorepo's Docker Compose example includes Erigon services, but it may still reference an older
-published Erigon image, for example `erigontech/erigon:2.61.0`.
-
-:::warning
-
-Until an official Erigon `v3.5` or later image is published, do not use the Erigon image tag already
-set in the monorepo compose file. Replace the Erigon image in both `erigon-init` and `erigon-node`
-with the local image you built in Step 1.
-
-:::
-
-```yaml
-erigon-init:
-  image: erigon-linea:pr-20298
-
-erigon-node:
-  image: erigon-linea:pr-20298
-```
-
-Also make sure Erigon initializes the same data directory that the node uses. The compose example
-mounts the Erigon volume at `/home/erigon/.local/share/erigon/`; if `erigon-init` still has
-`--datadir=/data`, change it to:
-
-```yaml
-erigon-init:
-  command:
-    - init
-    - /genesis.json
-    - --datadir=/home/erigon/.local/share/erigon
-```
-
-When an official Erigon `v3.5` or later image is published, replace `erigon-linea:pr-20298` with the
-official release image tag.
-
-### Step 4. Start the Erigon node
-
-In a terminal, navigate to the Linea monorepo directory for your network. Start the Erigon services
-from that compose file:
+In a terminal, navigate to the Linea monorepo directory for your network. Start the Erigon and
+Maru services from the compose file:
 
 ```bash
-docker compose up erigon-init erigon-node
+docker compose up erigon-init erigon-node maru-node
 ```
 
 The compose file initializes Erigon from the Geth genesis JSON, then starts the Erigon execution
-client. Keep [Maru](./maru.mdx) running alongside your chosen execution client for a full Linea
-node.
+client with `--externalcl` so [Maru](./maru.mdx) drives block delivery over the Engine API. Erigon
+also bootstraps its execution stage from genesis via its own block downloader, then meets the
+Maru-driven tip via backward download.
 
 ## Alternative: Run using the binary distribution
 
 :::info
-Until an official Erigon `v3.5` or later release is published, use a binary built from the
-[#20298 merge commit](https://github.com/erigontech/erigon/pull/20298) rather than a published
-release binary. Ensure you review
+Stock Erigon does not sync current Linea from scratch (see the warning above). Build the binary
+from Erigon `v3.3.0` and apply the three patches below before running. Ensure you review
 [Erigon's software prerequisites](https://docs.erigon.tech/get-started/hardware-requirements)
 before building the Erigon client.
 
@@ -161,12 +130,23 @@ instead.
 
 ### Step 1. Build Erigon
 
-Build Erigon from the #20298 merge commit:
+Build Erigon from `v3.3.0` and apply the three Linea patches (the same patches used by the
+`linea-erigon:v3.3.0-linea-patched` Docker image):
 
 ```bash
 git clone https://github.com/erigontech/erigon.git
 cd erigon
-git checkout 34ac22904b0de1b14cf054a7cf2c0d02461215f3
+git checkout v3.3.0
+
+# Patch 1: enable EL-driven block download (bootstrap fix for #22081)
+sed -i 's/const sentryMcDisableBlockDownload = true/const sentryMcDisableBlockDownload = false/' node/eth/backend.go
+
+# Patch 2: EIP-7002 empty-code syscall returns nil (Fusaka fix for #18160)
+sed -i 's/return nil, fmt.Errorf("\[EIP-7002\] Syscall failure: Empty Code at WithdrawalRequestAddress=%x", params.WithdrawalRequestAddress)/return nil, nil/' execution/protocol/rules/misc/eip7002.go
+
+# Patch 3: EIP-7251 empty-code syscall returns nil (Fusaka fix for #18160)
+sed -i 's/return nil, fmt.Errorf("\[EIP-7251\] Syscall failure: Empty Code at ConsolidationRequestAddress=%x", params.ConsolidationRequestAddress)/return nil, nil/' execution/protocol/rules/misc/eip7251.go
+
 make erigon
 ```
 

--- a/docs/network/how-to/run-a-node/index.mdx
+++ b/docs/network/how-to/run-a-node/index.mdx
@@ -36,7 +36,7 @@ to Linea-specific features.
     </tr>
     <tr>
       <td>[Erigon](./erigon.mdx)</td>
-      <td>A Go-based Ethereum client focused on performance and saving disk space. Until a published Erigon `v3.5` or later image is available, build the image from the Linea support merge commit.</td>
+      <td>A Go-based Ethereum client focused on performance and saving disk space. Stock Erigon does not sync current Linea from scratch, so build the locally patched `linea-erigon:v3.3.0-linea-patched` image from the Linea monorepo.</td>
       <td>❌</td>
     </tr>
   </tbody>
@@ -60,8 +60,8 @@ Quick steps:
 Next actions:
 - Default compose examples: [Linea Besu](./linea-besu.mdx) and [Maru](./maru.mdx).
 - Alternative EL clients: [Besu](./besu.mdx), [Geth](./geth.mdx), or [Erigon](./erigon.mdx) to follow the chain.
-  Erigon currently requires a locally built image until a published Erigon `v3.5` or later release is
-  available.
+  Erigon requires a locally built patched image (`linea-erigon:v3.3.0-linea-patched`); stock Erigon
+  does not sync current Linea from scratch.
 - Upgrades: see [upgrade guides](./beta-v4-migration.mdx).
 - Bootnodes: see [bootnodes](./bootnodes.mdx) if you need to override defaults.
 

--- a/docs/network/how-to/run-a-node/index.mdx
+++ b/docs/network/how-to/run-a-node/index.mdx
@@ -36,7 +36,7 @@ to Linea-specific features.
     </tr>
     <tr>
       <td>[Erigon](./erigon.mdx)</td>
-      <td>A Go-based Ethereum client focused on performance and saving disk space. Stock Erigon does not sync current Linea from scratch, so build the locally patched `linea-erigon:v3.3.0-linea-patched` image from the Linea monorepo.</td>
+      <td>A Go-based Ethereum client focused on performance and saving disk space.</td>
       <td>❌</td>
     </tr>
   </tbody>

--- a/sidebars.js
+++ b/sidebars.js
@@ -85,8 +85,6 @@ const sidebars = {
       label: "How to",
       collapsible: false,
       items: [
-        "network/how-to/recover-state",
-        "network/how-to/write-and-deploy-assertions",
         {
           type: "doc",
           id: "network/how-to/gas-fees",
@@ -96,37 +94,6 @@ const sidebars = {
           type: "doc",
           id: "network/how-to/bridge",
           label: "Bridge tokens to Linea",
-        },
-        {
-          type: "doc",
-          id: "network/how-to/connect-wallet",
-          label: "Connect a wallet to your dapp",
-        },
-        {
-          type: "category",
-          label: "Deploy a smart contract",
-          collapsible: true,
-          collapsed: true,
-          link: { type: "doc", id: "network/how-to/deploy-smart-contract/index" },
-          items: [
-            "network/how-to/deploy-smart-contract/thirdweb",
-            "network/how-to/deploy-smart-contract/remix",
-            "network/how-to/deploy-smart-contract/hardhat",
-            "network/how-to/deploy-smart-contract/cookbook",
-            "network/how-to/deploy-smart-contract/foundry",
-            "network/how-to/deploy-smart-contract/atlas",
-          ],
-        },
-        "network/how-to/deploy-subdomain",
-        {
-          type: "doc",
-          id: "network/how-to/fallback",
-          label: "Add a fallback for RPC requests",
-        },
-        {
-          type: "doc",
-          id: "network/how-to/migrate-dapp",
-          label: "Migrate a dapp to Linea",
         },
         {
           type: "category",
@@ -145,6 +112,28 @@ const sidebars = {
           ],
         },
         {
+          type: "doc",
+          id: "network/how-to/connect-wallet",
+          label: "Connect a wallet to your dapp",
+        },
+        "network/how-to/recover-state",
+        "network/how-to/write-and-deploy-assertions",
+        {
+          type: "category",
+          label: "Deploy a smart contract",
+          collapsible: true,
+          collapsed: true,
+          link: { type: "doc", id: "network/how-to/deploy-smart-contract/index" },
+          items: [
+            "network/how-to/deploy-smart-contract/thirdweb",
+            "network/how-to/deploy-smart-contract/remix",
+            "network/how-to/deploy-smart-contract/hardhat",
+            "network/how-to/deploy-smart-contract/cookbook",
+            "network/how-to/deploy-smart-contract/foundry",
+            "network/how-to/deploy-smart-contract/atlas",
+          ],
+        },
+        {
           type: "category",
           label: "Verify a smart contract",
           collapsible: true,
@@ -155,6 +144,17 @@ const sidebars = {
             "network/how-to/verify-smart-contract/foundry",
             "network/how-to/verify-smart-contract/atlas",
           ],
+        },
+        "network/how-to/deploy-subdomain",
+        {
+          type: "doc",
+          id: "network/how-to/fallback",
+          label: "Add a fallback for RPC requests",
+        },
+        {
+          type: "doc",
+          id: "network/how-to/migrate-dapp",
+          label: "Migrate a dapp to Linea",
         },
         {
           type: "doc",


### PR DESCRIPTION
## Summary
- Updates the Erigon page to instruct users to build the patched `linea-erigon:v3.3.0-linea-patched` image locally from the Dockerfile shipped in the [lineth-monorepo](https://github.com/LFDT-Lineth/lineth-monorepo), instead of building from the #20298 merge commit.
- Documents why stock Erigon does not sync current Linea from scratch and the three patches the image applies.
- Updates the binary distribution alternative to build from Erigon `v3.3.0` with the same three patches.
- Updates the run-a-node index/overview page (table cell + quickstart note) to drop the stale "Linea support merge commit" / "v3.5 or later" framing and point operators to the patched image.

## Why
Stock Erigon does not sync current Linea from scratch:
- `erigontech/erigon:v3.5.0` with `--externalcl` + Maru hangs at block 0 ([erigontech/erigon#22081](https://github.com/erigontech/erigon/issues/22081)).
- Earlier versions hit `[EIP-7002] Syscall failure: Empty Code` at the Fusaka fork ([erigontech/erigon#18160](https://github.com/erigontech/erigon/issues/18160)).

The patched image applies three fixes on top of Erigon `v3.3.0`:
- `sentryMcDisableBlockDownload = false` (enables EL-driven bootstrap from genesis)
- EIP-7002 empty-code syscall returns `nil` instead of erroring (Fusaka fix)
- EIP-7251 empty-code syscall returns `nil` instead of erroring (Fusaka fix)

## Test plan
- [x] Build the image: `make build` from `lineth-monorepo/docs/getting-started/linea-mainnet/erigon-linea/`
- [x] Follow the updated Docker steps on the Erigon page; confirm `docker compose up erigon-init erigon-node maru-node` begins syncing
- [x] Confirm the binary alternative builds with the three `sed` patches

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and navigation-only changes with no runtime or application code impact.
>
> **Overview**
> **Erigon run-a-node guidance** no longer tells operators to build from upstream PR #20298 or wait for Erigon `v3.5`. It now states that **stock Erigon cannot sync current Linea from genesis**, cites [#22081](https://github.com/erigontech/erigon/issues/22081) and [#18160](https://github.com/erigontech/erigon/issues/18160), and documents the **`linea-erigon:v3.3.0-linea-patched`** image built from `lineth-monorepo/docs/getting-started/linea-mainnet/erigon-linea/` with three named fixes (EL block download, EIP-7002/7251 empty-code syscalls).
>
> The Docker flow is **simplified**: build via `make build` (optional `PLATFORM=linux/arm64`), drop manual compose image/datadir/genesis copy steps, and start **`erigon-init`, `erigon-node`, and `maru-node`** together with a short note on `--externalcl` and bootstrap behavior. The **binary path** mirrors the same three `sed` patches on Erigon `v3.3.0`.
>
> The **run-a-node index** table and quickstart call out the patched image requirement instead of a pending `v3.5` release. **`sidebars.js`** reorders the How-to section (e.g. **Run a node** moved up; recover-state / assertions repositioned).
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccbfafe5ae17a072f1ce6d9b46ab229c88afda8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
