### PR TITLE
Add SwiftNodes to the Linea RPC providers list

### DIFF
--- a/docs/network/build/tools/node-providers/index.mdx
+++ b/docs/network/build/tools/node-providers/index.mdx
@@ -67,6 +67,11 @@ image: /img/socialCards/node-providers.jpg
     <td>:white_check_mark:</td>
   </tr>
   <tr>
+    <td><a href="https://swiftnodes.io/linea-rpc">SwiftNodes</a></td>
+    <td>:x:</td>
+    <td>:white_check_mark:</td>
+  </tr>
+  <tr>
     <td><a href="https://unifra.io/">Unifra</a></td>
     <td>:x:</td>
     <td>:white_check_mark:</td>


### PR DESCRIPTION
Follows up on #1666, which was approved for a PR.

Adds SwiftNodes to the **Private RPC endpoints** table, inserted alphabetically between QuickNode and Unifra:

| Provider | Linea API methods | WebSocket |
|---|---|---|
| SwiftNodes | :x: | :white_check_mark: |

SwiftNodes provides Linea mainnet (chain ID 59144) RPC over both HTTP and WebSocket. WebSocket is supported (hence :white_check_mark:); the custom Linea API methods such as `linea_estimateGas` are not implemented, so that column is :x:. Provider page: https://swiftnodes.io/linea-rpc

Resolves #1666.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only table update with no runtime or security impact.
> 
> **Overview**
> Adds **SwiftNodes** to the private RPC endpoints table in the node providers docs, placed alphabetically between QuickNode and Unifra.
> 
> The new row links to `https://swiftnodes.io/linea-rpc` and marks **WebSocket** as supported while **Linea API methods** (e.g. `linea_estimateGas`) as not supported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7209e6e6c39fa37b3a95cfebe1a1ab4ebb0f605. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->