### PR TITLE
Edit tokenomics

### DIFF
--- a/docs/network/overview/tokenomics.mdx
+++ b/docs/network/overview/tokenomics.mdx
@@ -5,27 +5,19 @@ sidebar_position: 4
 image: /img/socialCards/tokenomics.jpg
 ---
 
-The LINEA token grows and supports Ethereum and Linea, and has several features
-that set it apart from many other layer 2 tokens:
+LINEA is the token of Linea Mainnet, designed to grow and support Ethereum and Linea.
+You do not need it to use the network: gas is paid in ETH, and LINEA has no governance rights.
+Surplus network revenue is [burned as ETH and LINEA](#burning-mechanism).
 
-- ETH is the gas token
-- LINEA does not come with any governance rights
-- There is no token allocation for insiders, investors, or team members
-- Surplus revenue is [burned as ETH and LINEA](#burning-mechanism)
-
-Instead, LINEA is distributed to users as a reward for using apps and protocols on the
+LINEA has no allocation for insiders, investors, or team members.
+LINEA is distributed to users as a reward for using apps and protocols on the
 Linea network.
+
+This page explains how LINEA is allocated and how it entered circulation.
+For help using the token, see the [Linea support page](/support).
 
 The token's contract address on Linea Mainnet and Ethereum Mainnet is
 [`0x1789e0043623282D5DCc7F213d703C6D8BAfBB04`](https://lineascan.build/address/0x1789e0043623282D5DCc7F213d703C6D8BAfBB04).
-
-:::note[Need help?]
-
-This page explains the rationale behind token distribution.
-If you're looking for help with using the token, or any other common issues, see the
-[Linea support page](/support).
-
-:::
 
 ## Allocation
 

--- a/docs/network/overview/tokenomics.mdx
+++ b/docs/network/overview/tokenomics.mdx
@@ -10,7 +10,8 @@ that set it apart from many other layer 2 tokens:
 
 - ETH is the gas token
 - LINEA does not come with any governance rights
-- There is no token allocation for insiders, investors, or team members.
+- There is no token allocation for insiders, investors, or team members
+- Surplus revenue is [burned as ETH and LINEA](#burning-mechanism)
 
 Instead, LINEA is distributed to users as a reward for using apps and protocols on the
 Linea network.

--- a/docs/network/overview/tokenomics.mdx
+++ b/docs/network/overview/tokenomics.mdx
@@ -5,31 +5,32 @@ sidebar_position: 4
 image: /img/socialCards/tokenomics.jpg
 ---
 
-The LINEA token is designed to grow and support Ethereum and Linea, and has several radical features 
-that set it apart from most layer 2 tokens:
+The LINEA token grows and supports Ethereum and Linea, and has several features
+that set it apart from many other layer 2 tokens:
+
 - ETH is the gas token
 - LINEA does not come with any governance rights
-- There is no token allocation for insiders, investors, or team members.
+- There's no token allocation for insiders, investors, or team members.
 
-Instead, LINEA will help to organically grow the chain by being distributed to users as a reward for 
-using apps and protocols on Linea. 
+Instead, LINEA is distributed to users as a reward for using apps and protocols on the Linea network.
 
-The token's contract address on Linea Mainnet and Ethereum Mainnet is [`0x1789e0043623282D5DCc7F213d703C6D8BAfBB04`](https://lineascan.build/address/0x1789e0043623282D5DCc7F213d703C6D8BAfBB04).
+The token's contract address on Linea Mainnet and Ethereum Mainnet is
+[`0x1789e0043623282D5DCc7F213d703C6D8BAfBB04`](https://lineascan.build/address/0x1789e0043623282D5DCc7F213d703C6D8BAfBB04).
 
 :::note[Need help?]
 
-This page explains the rationale behind token distribution. If you're looking for help with claiming 
-your airdrop, using the token, or any other common issues, see the [Linea support page](/support).
+This page explains the rationale behind token distribution. If you're looking for help with using
+the token, or any other common issues, see the [Linea support page](/support).
 
 :::
 
 ## Allocation
 
-LINEA will have a **total supply of 72,009,990,000**. This 1,000x the genesis supply of ETH on 
-Ethereum.
+LINEA had a **genesis supply of 72,009,990,000**. This is 1,000x the genesis supply of ETH on
+Ethereum. Burns reduce that amount over time; see the [token contract](https://lineascan.build/token/0x1789e0043623282D5DCc7F213d703C6D8BAfBB04) for the live `totalSupply()`.
 
-85% of the supply of LINEA will be be invested in the community and ecosystem, comprising the 
-Ecosystem Fund, with 15% held long-term by Consensys.
+85% of the LINEA supply is allocated to the community and ecosystem, comprising the
+Ecosystem fund, with 15% held long-term by Consensys.
 
 <div class="center-container">
   <div class="img-large">
@@ -40,7 +41,7 @@ Ecosystem Fund, with 15% held long-term by Consensys.
   </div>
 </div>
 
-The supply will be allocated according to the below table:
+The supply is allocated according to the below table:
 
 <table>
 	<tr>
@@ -51,49 +52,48 @@ The supply will be allocated according to the below table:
 	<tr>
 		<td>Ecosystem</td>
 		<td>85%</td>
-		<td>75% for a long-term Ecosystem Fund, and 10% for early contributors.</td>
+		<td>75% for a long-term Ecosystem fund, and 10% for early contributors.</td>
 	</tr>
 	<tr>
 		<td>Consensys treasury</td>
 		<td>15%</td>
-		<td>Locked (non-transferrable) for five years. Consensys will hold the tokens long-term for 
+		<td>Locked (non-transferable) for five years. Consensys holds the tokens long-term for
 		alignment and to support Linea and its ecosystem.</td>
 	</tr>
 </table>
 
-Except from the initial allocation to Consensys, which is locked for five years, there is **no 
-allocation to private investors, insiders, or employees and team members**. Instead, value is 
-funneled straight into the ecosystem, the builders bringing it to fruition, and the community members 
-engaging with it. 
+Except for the initial allocation to Consensys, which is locked for five years, there is **no
+allocation to private investors, insiders, or employees and team members**. Instead, value is
+funneled straight into the ecosystem, the builders bringing it to fruition, and the community members
+engaging with it.
 
-At the time of the token generation event (TGE), 22% of the LINEA supply will be in circulation, 
+At the token generation event (TGE), 22% of the LINEA supply entered circulation,
 split between a user and builder airdrop, ecosystem activations, and liquidity provisioning.
 
-All other allocations will be locked at TGE, or vesting according to various schedules.
+All other allocations were locked at TGE, or vest according to various schedules.
 
 ## Ecosystem (85%)
 
 ### Early contributors (10%)
 
-The initial airdrop for early contributors, comprising 10% of the supply, will include:
+The initial airdrop for early contributors comprised 10% of the supply:
 - 9% to early contributors
 - 1% to strategic builders
 
-The early contributor airdrop for users will be based on onchain activity over the long term, including 
-LXP. An eligibility checker will be available before TGE. The 1% allocation for builders will be 
-distributed through a curated, targeted process for maximum impact.
-	
-All tokens distributed through the above airdrops are fully unlocked.
+The user airdrop was based on onchain activity over the long term, including Linea Voyage XP (LXP).
+The 1% allocation for strategic builders is distributed through a curated, targeted process.
 
-### Ecosystem Fund (75%)
+All tokens distributed through these airdrops are fully unlocked.
 
-The long-term section of the Ecosystem Fund will be managed by the Linea Consortium.
+### Ecosystem fund (75%)
 
-This 75% will unlock over 10 years, with unlocks weighted towards the earlier years to encourage 
-early activation and adoption. Unlocks occur early — 10% per year in the early years, tapering to 2% 
+The long-term section of the Ecosystem Fund is managed by the Linea Consortium.
+
+This 75% unlocks over 10 years, with unlocks weighted towards the earlier years to encourage
+early activation and adoption. Unlocks occur early; 10% per year in the early years, tapering to 2%
 by the tenth year.
 
-These funds will be used for:
+These funds are used for:
 - Funding for Ethereum R&D
 - Maintaining shared ecosystem infrastructure such as audits, developer tools, and node infrastructure
 - Funding public goods, such as open-source software, research, and community programs
@@ -101,8 +101,8 @@ These funds will be used for:
 
 ## Consensys treasury (15%)
 
-15% of the total token supply will be incorporated into the Consensys treasury. This allocation will 
-be locked for five years and is non-transferrable until a vesting schedule is complete.
+15% of the total token supply is held in the Consensys treasury. This allocation is
+locked for five years and is non-transferable until a vesting schedule is complete.
 
 ## Burning mechanism
 
@@ -113,63 +113,64 @@ After covering infrastructure costs, 100% of surplus revenue gets burned:
 
 ### How burning works on Linea
 
-Linea and the LINEA token are designed specifically to reinforce the strength of Ethereum and ETH, 
+Linea and the LINEA token are designed specifically to reinforce the strength of Ethereum and ETH,
 achieved through an automatic, dual-burn mechanism:
+
 - All gas fees on Linea are paid in ETH
-- 20% of net ETH profits (Linea revenue minus operating costs and subsidies) will be burned, 
+- 20% of net ETH profits (Linea revenue minus operating costs and subsidies) is burned,
   reducing ETH supply
 - 80% of net ETH profits are used to burn LINEA, reducing LINEA supply.
 
-As a result, network activity on Linea directly supports both the value of ETH and LINEA. 
+As a result, network activity on Linea directly supports both the value of ETH and LINEA.
 
-Every transaction on Linea generates gas fees paid in ETH. Instead of keeping these fees, Linea's 
-burn mechanism permanently removes ETH and LINEA tokens from circulation. This creates deflationary 
+Every transaction on Linea generates gas fees paid in ETH. Instead of keeping these fees, Linea's
+burn mechanism permanently removes ETH and LINEA tokens from circulation. This creates deflationary
 pressure on both tokens, directly benefiting holders and the broader ecosystem.
 
 This means Linea becomes a perpetual buyer of its own token while simultaneously reducing ETH supply.
 
 #### Step 1: Revenue collection
 
-All gas fees from transactions on Linea are paid in ETH and automatically collected into a revenue 
-vault contract. This happens continuously as users interact with the network—every swap, transfer, 
+All gas fees from transactions on Linea are paid in ETH and automatically collected into a revenue
+vault contract. This happens continuously as users interact with the network. Every swap, transfer,
 NFT mint, or smart contract interaction contributes to this pool.
 
 #### Step 2: Covering infrastructure costs
 
 Running a high-performance layer 2 network has real costs:
-- **Onchain costs**: Submitting transaction data to Ethereum L1, finalizing proofs, bridge 
+- **Onchain costs**: Submitting transaction data to Ethereum L1, finalizing proofs, bridge
   transactions (anchoring and claiming)
 - **Offchain costs**: Running the mainnet infrastructure (servers, databases, monitoring systems)
 
-Once calculated, an invoice is submitted to the revenue vault. The vault automatically pays what it 
-can from available funds. If there's not enough balance, it tracks the outstanding amount (called 
+Once calculated, an invoice is submitted to the revenue vault. The vault automatically pays what it
+can from available funds. If there's not enough balance, it tracks the outstanding amount (called
 "arrears") and pays it off when more revenue comes in.
 
 Infrastructure costs are always paid first. Burns only happen when there's surplus revenue.
 
 #### Step 3: The burn operation
 
-Once costs are covered and there's surplus revenue available, the burn operation is triggered by a 
+Once costs are covered and there's surplus revenue available, the burn operation is triggered by a
 service operated by the Linea Consortium on a regular basis:
 
-##### ETH Burn (20%)
+##### ETH burn (20%)
 
-The vault takes 20% of the available surplus and sends it directly to the zero address (0x0000000000000000000000000000000000000000). 
+The vault takes 20% of the available surplus and sends it directly to the zero address (0x0000000000000000000000000000000000000000).
 This ETH is permanently removed from circulation; it can never be recovered or used again.
 
-##### LINEA Burn (80%)
+##### LINEA burn (80%)
 
 The remaining 80% goes through a more complex process:
-1. **Swap**: The ETH is swapped for LINEA tokens using a decentralized exchange (DEX) on Linea. 
-  This creates buying pressure on LINEA and happens at the current market rate with slippage 
+1. **Swap**: The ETH is swapped for LINEA tokens using a decentralized exchange (DEX) on Linea.
+  This creates buying pressure on LINEA and happens at the current market rate with slippage
   protection to prevent unfavorable trades.
-2. **Bridge**: The LINEA tokens are then bridged from Linea (L2) to Ethereum (L1) using Linea's 
+2. **Bridge**: The LINEA tokens are then bridged from Linea (L2) to Ethereum (L1) using Linea's
   native token bridge. They're sent to a special burner contract on L1.
-3. **Burn**: On Ethereum L1, the LINEA tokens are permanently burned. This is important because 
-  LINEA's total supply is tracked on L1, so burning must happen there to properly reduce the 
+3. **Burn**: On Ethereum L1, the LINEA tokens are permanently burned. This is important because
+  LINEA's total supply is tracked on L1, so burning must happen there to properly reduce the
   circulating supply.
 
-The bridging and burning on L1 is designed to be permissionless: anyone can trigger the final burn 
+The bridging and burning on L1 is designed to be permissionless: anyone can trigger the final burn
 step, ensuring the process can't be blocked or censored.
 
 #### Step 4: Transparency
@@ -180,7 +181,7 @@ Every step of this process is recorded onchain:
 - Bridge transactions showing LINEA moving from L2 to L1
 - Final burn transactions on Ethereum L1
 
-You can verify everything yourself by checking the blockchain. The [**live dashboard**](https://dune.com/linea/burn-metrics) 
+You can verify everything yourself by checking the blockchain. The [**live dashboard**](https://dune.com/linea/burn-metrics)
 makes it easy to track:
 - Total gas fees collected
 - Total ETH burned since September 11, 2024

--- a/docs/network/overview/tokenomics.mdx
+++ b/docs/network/overview/tokenomics.mdx
@@ -12,22 +12,27 @@ that set it apart from many other layer 2 tokens:
 - LINEA does not come with any governance rights
 - There's no token allocation for insiders, investors, or team members.
 
-Instead, LINEA is distributed to users as a reward for using apps and protocols on the Linea network.
+Instead, LINEA is distributed to users as a reward for using apps and protocols on the
+Linea network.
 
 The token's contract address on Linea Mainnet and Ethereum Mainnet is
 [`0x1789e0043623282D5DCc7F213d703C6D8BAfBB04`](https://lineascan.build/address/0x1789e0043623282D5DCc7F213d703C6D8BAfBB04).
 
 :::note[Need help?]
 
-This page explains the rationale behind token distribution. If you're looking for help with using
-the token, or any other common issues, see the [Linea support page](/support).
+This page explains the rationale behind token distribution.
+If you're looking for help with using the token, or any other common issues, see the
+[Linea support page](/support).
 
 :::
 
 ## Allocation
 
-LINEA had a **genesis supply of 72,009,990,000**. This is 1,000x the genesis supply of ETH on
-Ethereum. Burns reduce that amount over time; see the [token contract](https://lineascan.build/token/0x1789e0043623282D5DCc7F213d703C6D8BAfBB04) for the live `totalSupply()`.
+LINEA had a **genesis supply of 72,009,990,000**.
+This is 1,000x the genesis supply of ETH on Ethereum.
+Burns reduce that amount over time; see the
+[token contract](https://lineascan.build/token/0x1789e0043623282D5DCc7F213d703C6D8BAfBB04)
+for the live `totalSupply()`.
 
 85% of the LINEA supply is allocated to the community and ecosystem, comprising the
 Ecosystem fund, with 15% held long-term by Consensys.
@@ -63,14 +68,16 @@ The supply is allocated according to the below table:
 </table>
 
 Except for the initial allocation to Consensys, which is locked for five years, there is **no
-allocation to private investors, insiders, or employees and team members**. Instead, value is
-funneled straight into the ecosystem, the builders bringing it to fruition, and the community members
-engaging with it.
+allocation to private investors, insiders, or employees and team members**.
+Instead, value is funneled straight into the ecosystem, the builders bringing it to
+fruition, and the community members engaging with it.
 
 At the token generation event (TGE), 22% of the LINEA supply entered circulation,
-split between a user and builder airdrop, ecosystem activations, and liquidity provisioning.
+split between a user and builder airdrop, ecosystem activations, and liquidity
+provisioning (DEX liquidity).
 
-All other allocations were locked at TGE, or vest according to various schedules.
+All other allocations were locked at TGE, or vest (released over time) according to
+various schedules.
 
 ## Ecosystem (85%)
 
@@ -90,19 +97,22 @@ All tokens distributed through these airdrops are fully unlocked.
 The long-term section of the Ecosystem Fund is managed by the Linea Consortium.
 
 This 75% unlocks over 10 years, with unlocks weighted towards the earlier years to encourage
-early activation and adoption. Unlocks occur early; 10% per year in the early years, tapering to 2%
-by the tenth year.
+early activation and adoption.
+Unlocks occur early; 10% per year in the early years, tapering to 2% by the tenth year.
 
 These funds are used for:
+
 - Funding for Ethereum R&D
-- Maintaining shared ecosystem infrastructure such as audits, developer tools, and node infrastructure
+- Maintaining shared ecosystem infrastructure such as audits, developer tools, and node
+  infrastructure
 - Funding public goods, such as open-source software, research, and community programs
-- Strategic co-development with aligned organizations or emerging protocols.
+- Strategic co-development with aligned organizations or emerging protocols
 
 ## Consensys treasury (15%)
 
-15% of the total token supply is held in the Consensys treasury. This allocation is
-locked for five years and is non-transferable until a vesting schedule is complete.
+15% of the total token supply is held in the Consensys treasury.
+This allocation is locked for five years and is non-transferable until a vesting
+schedule is complete.
 
 ## Burning mechanism
 
@@ -114,12 +124,7 @@ After covering infrastructure costs, 100% of surplus revenue gets burned:
 ### How burning works on Linea
 
 Linea and the LINEA token are designed specifically to reinforce the strength of Ethereum and ETH,
-achieved through an automatic, dual-burn mechanism:
-
-- All gas fees on Linea are paid in ETH
-- 20% of net ETH profits (Linea revenue minus operating costs and subsidies) is burned,
-  reducing ETH supply
-- 80% of net ETH profits are used to burn LINEA, reducing LINEA supply.
+achieved through an automatic, dual-burn mechanism.
 
 As a result, network activity on Linea directly supports both the value of ETH and LINEA.
 
@@ -127,13 +132,15 @@ Every transaction on Linea generates gas fees paid in ETH. Instead of keeping th
 burn mechanism permanently removes ETH and LINEA tokens from circulation. This creates deflationary
 pressure on both tokens, directly benefiting holders and the broader ecosystem.
 
-This means Linea becomes a perpetual buyer of its own token while simultaneously reducing ETH supply.
+This means Linea becomes a perpetual buyer of its own token while simultaneously reducing
+ETH supply.
 
 #### Step 1: Revenue collection
 
 All gas fees from transactions on Linea are paid in ETH and automatically collected into a revenue
-vault contract. This happens continuously as users interact with the network. Every swap, transfer,
-NFT mint, or smart contract interaction contributes to this pool.
+vault contract.
+This happens continuously as users interact with the network.
+Every swap, transfer, NFT mint, or smart contract interaction contributes to this pool.
 
 #### Step 2: Covering infrastructure costs
 
@@ -142,9 +149,10 @@ Running a high-performance layer 2 network has real costs:
   transactions (anchoring and claiming)
 - **Offchain costs**: Running the mainnet infrastructure (servers, databases, monitoring systems)
 
-Once calculated, an invoice is submitted to the revenue vault. The vault automatically pays what it
-can from available funds. If there's not enough balance, it tracks the outstanding amount (called
-"arrears") and pays it off when more revenue comes in.
+Once calculated, an invoice is submitted to the revenue vault.
+The vault automatically pays what it can from available funds.
+If there's not enough balance, it tracks the outstanding amount (called "arrears") and
+pays it off when more revenue comes in.
 
 Infrastructure costs are always paid first. Burns only happen when there's surplus revenue.
 
@@ -155,7 +163,8 @@ service operated by the Linea Consortium on a regular basis:
 
 ##### ETH burn (20%)
 
-The vault takes 20% of the available surplus and sends it directly to the zero address (0x0000000000000000000000000000000000000000).
+The vault takes 20% of the available surplus and sends it directly to the zero address
+(`0x0000000000000000000000000000000000000000`).
 This ETH is permanently removed from circulation; it can never be recovered or used again.
 
 ##### LINEA burn (80%)
@@ -181,7 +190,8 @@ Every step of this process is recorded onchain:
 - Bridge transactions showing LINEA moving from L2 to L1
 - Final burn transactions on Ethereum L1
 
-You can verify everything yourself by checking the blockchain. The [**live dashboard**](https://dune.com/linea/burn-metrics)
+You can verify everything yourself by checking the blockchain.
+The [**live dashboard**](https://dune.com/linea/burn-metrics)
 makes it easy to track:
 - Total gas fees collected
 - Total ETH burned since September 11, 2024

--- a/docs/network/overview/tokenomics.mdx
+++ b/docs/network/overview/tokenomics.mdx
@@ -10,7 +10,7 @@ that set it apart from many other layer 2 tokens:
 
 - ETH is the gas token
 - LINEA does not come with any governance rights
-- There's no token allocation for insiders, investors, or team members.
+- There is no token allocation for insiders, investors, or team members.
 
 Instead, LINEA is distributed to users as a reward for using apps and protocols on the
 Linea network.
@@ -35,7 +35,7 @@ Burns reduce that amount over time; see the
 for the live `totalSupply()`.
 
 85% of the LINEA supply is allocated to the community and ecosystem, comprising the
-Ecosystem fund, with 15% held long-term by Consensys.
+Ecosystem Fund, with 15% held long-term by Consensys.
 
 <div class="center-container">
   <div class="img-large">
@@ -57,7 +57,7 @@ The supply is allocated according to the below table:
 	<tr>
 		<td>Ecosystem</td>
 		<td>85%</td>
-		<td>75% for a long-term Ecosystem fund, and 10% for early contributors.</td>
+		<td>75% for a long-term Ecosystem Fund, and 10% for early contributors.</td>
 	</tr>
 	<tr>
 		<td>Consensys treasury</td>
@@ -92,7 +92,7 @@ The 1% allocation for strategic builders is distributed through a curated, targe
 
 All tokens distributed through these airdrops are fully unlocked.
 
-### Ecosystem fund (75%)
+### Ecosystem Fund (75%)
 
 The long-term section of the Ecosystem Fund is managed by the Linea Consortium.
 
@@ -118,8 +118,8 @@ schedule is complete.
 
 After covering infrastructure costs, 100% of surplus revenue gets burned:
 
-- **20% burned as ETH**
-- **80% converted to LINEA and burned**
+- **20% of surplus revenue burned as ETH**
+- **80% of surplus revenue converted to LINEA and burned**
 
 ### How burning works on Linea
 

--- a/docs/network/overview/tokenomics.mdx
+++ b/docs/network/overview/tokenomics.mdx
@@ -29,10 +29,11 @@ If you're looking for help with using the token, or any other common issues, see
 ## Allocation
 
 LINEA had a **genesis supply of 72,009,990,000**.
-This is 1,000x the genesis supply of ETH on Ethereum.
-Burns reduce that amount over time; see the
-[token contract](https://lineascan.build/token/0x1789e0043623282D5DCc7F213d703C6D8BAfBB04)
-for the live `totalSupply()`.
+This is 1,000x the genesis supply of ETH on Ethereum, and is the maximum supply.
+Burns reduce circulating LINEA over time; they are executed on Ethereum L1.
+Track burn totals on the [Dune dashboard](https://dune.com/linea/burn-metrics)
+or [growthepie](https://www.growthepie.com/quick-bites/linea-burn), not via
+`totalSupply()` on Linea or Ethereum.
 
 85% of the LINEA supply is allocated to the community and ecosystem, comprising the
 Ecosystem Fund, with 15% held long-term by Consensys.
@@ -191,11 +192,12 @@ Every step of this process is recorded onchain:
 - Final burn transactions on Ethereum L1
 
 You can verify everything yourself by checking the blockchain.
-The [**live dashboard**](https://dune.com/linea/burn-metrics)
-makes it easy to track:
+The [**Dune dashboard**](https://dune.com/linea/burn-metrics) and
+[growthepie burn tracker](https://www.growthepie.com/quick-bites/linea-burn)
+make it easy to track:
 - Total gas fees collected
-- Total ETH burned since September 11, 2024
-- Total LINEA burned since September 11, 2024
+- Total ETH burned since September 11, 2025
+- Total LINEA burned since September 11, 2025
 - Daily burn amounts for both tokens
 - Historical trends and charts
 

--- a/docs/network/overview/tokenomics.mdx
+++ b/docs/network/overview/tokenomics.mdx
@@ -32,8 +32,7 @@ LINEA had a **genesis supply of 72,009,990,000**.
 This is 1,000x the genesis supply of ETH on Ethereum, and is the maximum supply.
 Burns reduce circulating LINEA over time; they are executed on Ethereum L1.
 Track burn totals on the [Dune dashboard](https://dune.com/linea/burn-metrics)
-or [growthepie](https://www.growthepie.com/quick-bites/linea-burn), not via
-`totalSupply()` on Linea or Ethereum.
+or [growthepie](https://www.growthepie.com/quick-bites/linea-burn).
 
 85% of the LINEA supply is allocated to the community and ecosystem, comprising the
 Ecosystem Fund, with 15% held long-term by Consensys.


### PR DESCRIPTION
# Description

Post-TGE refresh of the LINEA tokenomics page: move completed events into the past, keep ongoing mechanics in the present, and stop treating genesis supply as the live total.

## Changes

- **Tense and status**: TGE, user airdrop, and initial locks are past tense. Ecosystem Fund unlocks, Consensys lock, builder 1% allocation, and the burn mechanism stay present tense.
- **Supply**: 72,009,990,000 is genesis supply, not current total. Burns reduce supply.
- **Dead pre-TGE UX**: Removed the eligibility-checker CTA and airdrop-claim help from the support note (claim window is closed). Support now covers using the token.
- **Airdrop**: Expanded LXP to Linea Voyage XP. User airdrop is historical; the 1% strategic-builder allocation is still described as an ongoing curated process. Glossed DEX liquidity and vesting.
- **Copy and structure**: Dropped duplicate 20/80 burn bullets (lead + steps remain). Consistent Ecosystem Fund naming, no contractions on “there is”, “non-transferable”, “except for”, sentence-case burn headings, semantic line breaks.
Burn contracts, 20/80 split, 85/15 and 75/10 allocations, no-governance, five-year Consensys lock, and the Dune dashboard are unchanged.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording and links on the tokenomics page; no application or on-chain logic changes.
> 
> **Overview**
> Updates **`tokenomics.mdx`** so the LINEA tokenomics story matches life after TGE: completed milestones are **past tense** (TGE circulation, user airdrop, initial locks), while ongoing mechanics stay **present** (Ecosystem Fund unlocks, builder allocation process, burn flow).
> 
> **Supply and allocation copy** now treats **72,009,990,000** as **genesis / max supply**, notes that **L1 burns** shrink circulating LINEA, and adds **growthepie** alongside Dune for burn metrics. The old **:::note** block with pre-TGE **eligibility checker** and claim help is removed; support is pointed to inline for **using the token**.
> 
> **Airdrop section** reframes the user drop as historical, spells out **Linea Voyage XP (LXP)**, glosses **DEX liquidity** and **vesting**, and trims redundant burn bullets under “How burning works” while keeping the step-by-step flow. Minor editorial fixes (**non-transferable**, **except for**, sentence-case burn headings, line breaks). Transparency bullets now say burns are tracked **since September 11, 2025** (was 2024). Contract addresses and the 20/80 burn split are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54c5421bf44ead3ec8c33c1aa5e77a0b74807642. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->