### PR TITLE
chore(misc): update nonce 78 on L1

### DIFF
--- a/docs/changelog/security-council-record.mdx
+++ b/docs/changelog/security-council-record.mdx
@@ -20,7 +20,7 @@ Transactions are designated by their nonce, and each entry details the action ta
 you can take to verify this information. 
 
 ### September 01, 2026
-- **[Nonce 78](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3)**
+- **[Nonce 78](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3&id=multisig_0x892bb7EeD71efB060ab90140e7825d8127991DD3_0x3d7906421672a76d7718147f1c2067b2c2e41d01f3378a6808c11e2a0234456f)**
   - Actions: 
     - Upgrade the LineaRollup implementation containing a fix for an incorrect message sender address on yield reporting.
     - Adjust Yield Manager parameters ramping up to 60% of funds.

--- a/docs/changelog/security-council-record.mdx
+++ b/docs/changelog/security-council-record.mdx
@@ -26,6 +26,9 @@ you can take to verify this information.
     - Adjust Yield Manager parameters ramping up to 60% of funds.
     - Call to the SafeExecutionConditions `0xe2ee8f0A648b8c29e72C61d65F46b7642fe83376` preventing execution before 9am UTC September 01 2026.
   - Verification
+      - [Links to audits](https://github.com/LFDT-Lineth/lineth-monorepo/blob/main/docs/audits.md#rollup-message-service-and-token-bridge)  
+        - Deployment addresses `0x052b73d934e9412045bf731574463fd026d74645` - see `Yield Manager Revision August 20th 2026`.
+      - `Upgraded` event with new implementation address `0x052b73d934e9412045bf731574463fd026d74645`
       - `WithdrawalReserveParametersSet` event
       - `newTargetWithdrawalReservePercentageBps` should change to `4000` from the old value of `9000`.
       - `newMinimumWithdrawalReservePercentageBps` should change to `3500` from the old value of `8500`.

--- a/docs/changelog/security-council-record.mdx
+++ b/docs/changelog/security-council-record.mdx
@@ -19,6 +19,18 @@ You can view the LSC account history here:
 Transactions are designated by their nonce, and each entry details the action taken and the steps
 you can take to verify this information. 
 
+### September 01, 2026
+- **[Nonce 78](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3)**
+  - Actions: 
+    - Upgrade the LineaRollup implementation containing a fix for an incorrect message sender address on yield reporting.
+    - Adjust Yield Manager parameters ramping up to 60% of funds.
+    - Call to the SafeExecutionConditions `0xe2ee8f0A648b8c29e72C61d65F46b7642fe83376` preventing execution before 9am UTC September 01 2026.
+  - Verification
+      - `WithdrawalReserveParametersSet` event
+      - `newTargetWithdrawalReservePercentageBps` should change to `4000` from the old value of `9000`.
+      - `newMinimumWithdrawalReservePercentageBps` should change to `3500` from the old value of `8500`.
+      - All other parameters old and new remain unchanged.
+
 ### July 14, 2026
 #### L1
 - **[Nonce 77](https://app.safe.global/transactions/tx?safe=eth:0x892bb7EeD71efB060ab90140e7825d8127991DD3&id=multisig_0x892bb7EeD71efB060ab90140e7825d8127991DD3_0xc4851acbe9045a5d9d14f340470987d40500464d8430feda1995eb67506dbafd)**


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only update to the public Security Council changelog; no application or contract code changes in this PR.
> 
> **Overview**
> Adds a **September 01, 2026** entry to the Linea Security Council transaction record for **L1 nonce 78**, placed above the existing July 2026 entries.
> 
> The new section documents the multisig actions (LineaRollup implementation upgrade for a yield-reporting message-sender fix, Yield Manager reserve ramp toward **60%** of funds, and a **SafeExecutionConditions** call blocking execution before 9am UTC) and gives verification steps: audit links, expected **`Upgraded`** implementation **`0x052b73d934e9412045bf731574463fd026d74645`**, and **`WithdrawalReserveParametersSet`** bps changes (**target 9000→4000**, **minimum 8500→3500**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c7ec166478cedad3a37f97e9785a057ad19d0db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->