### PR TITLE
docs(stack): add cryptographic primitives section to security page

### DIFF
--- a/docs/stack/evaluate/security.mdx
+++ b/docs/stack/evaluate/security.mdx
@@ -72,8 +72,7 @@ mechanics, see the
 
 ## Cryptographic primitives
 
-The Lineth stack relies on the following cryptographic primitives. Where a primitive
-corresponds to a published standard, the table flags it.
+The following table outlines the cryptographic primitives Lineth relies on, where they are used in the stack, and what standards they correspond to.
 
 | Primitive | Where the stack uses it | Standard |
 | --- | --- | --- |

--- a/docs/stack/evaluate/security.mdx
+++ b/docs/stack/evaluate/security.mdx
@@ -82,7 +82,7 @@ The following table outlines the cryptographic primitives Lineth relies on, wher
 | TLS | Service-to-service and RPC endpoints | Standard TLS. Configuration is per deployment. |
 | Key custody | Remote signing through [Web3Signer](../../protocol/architecture/index.mdx#web3signer), with optional AWS KMS-backed secp256k1 signing | AWS KMS uses FIPS 140-2 and FIPS 140-3 validated HSMs (validations held by AWS). Key custody is a deployment choice. |
 
-All signing and hashing go through established libraries (Besu, web3j, Tuweni,
+All signing and hashing go through established libraries (Besu, web3j, Tuweni, and
 BouncyCastle) or AWS KMS. The stack does not implement custom cryptographic primitives.
 
 ## Available evidence

--- a/docs/stack/evaluate/security.mdx
+++ b/docs/stack/evaluate/security.mdx
@@ -77,7 +77,7 @@ corresponds to a published standard, the table flags it.
 
 | Primitive | Where the stack uses it | Standard |
 | --- | --- | --- |
-| ECDSA over secp256k1 | Transaction signing and validator signing | Ethereum-standard curve. Not a NIST-approved curve. |
+| ECDSA over secp256k1 | Transaction signing and validator signing | Ethereum-standard curve. |
 | ECDSA over secp256r1 (P-256) | Available to smart contracts through the `P256VERIFY` precompile ([RIP-7212](https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md)) | Curve approved under [FIPS 186-5](https://csrc.nist.gov/pubs/fips/186-5/final) |
 | Keccak-256 | EVM hashing, state commitments, and role identifiers | Based on the Keccak permutation standardized in [FIPS 202](https://csrc.nist.gov/pubs/fips/202/final) (SHA-3 family). Ethereum uses the pre-standardization Keccak-256 padding, not the FIPS 202 SHA3-256 output. |
 | TLS | Service-to-service and RPC endpoints | Standard TLS. Configuration is per deployment. |

--- a/docs/stack/evaluate/security.mdx
+++ b/docs/stack/evaluate/security.mdx
@@ -82,9 +82,6 @@ The following table outlines the cryptographic primitives Lineth relies on, wher
 | TLS | Service-to-service and RPC endpoints | Standard TLS. Configuration is per deployment. |
 | Key custody | Remote signing through [Web3Signer](../../protocol/architecture/index.mdx#web3signer), with optional AWS KMS-backed secp256k1 signing | AWS KMS uses FIPS 140-2 and FIPS 140-3 validated HSMs (validations held by AWS). Key custody is a deployment choice. |
 
-All signing and hashing go through established libraries (Besu, web3j, Tuweni, and
-BouncyCastle) or AWS KMS. The stack does not implement custom cryptographic primitives.
-
 ## Available evidence
 
 The following public materials are the available assurance evidence for the Lineth stack:

--- a/docs/stack/evaluate/security.mdx
+++ b/docs/stack/evaluate/security.mdx
@@ -70,6 +70,22 @@ response, or control upgrade authority depending on the deployment. For upgrade
 mechanics, see the
 [OpenZeppelin Transparent Upgradeable Proxy pattern](../../protocol/architecture/smart-contracts.mdx#contract-versioning).
 
+## Cryptographic primitives
+
+The Lineth stack relies on the following cryptographic primitives. Where a primitive
+corresponds to a published standard, the table flags it.
+
+| Primitive | Where the stack uses it | Standard |
+| --- | --- | --- |
+| ECDSA over secp256k1 | Transaction signing and validator signing | Ethereum-standard curve. Not a NIST-approved curve. |
+| ECDSA over secp256r1 (P-256) | Available to smart contracts through the `P256VERIFY` precompile ([RIP-7212](https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md)) | Curve approved under [FIPS 186-5](https://csrc.nist.gov/pubs/fips/186-5/final) |
+| Keccak-256 | EVM hashing, state commitments, and role identifiers | Based on the Keccak permutation standardized in [FIPS 202](https://csrc.nist.gov/pubs/fips/202/final) (SHA-3 family). Ethereum uses the pre-standardization Keccak-256 padding, not the FIPS 202 SHA3-256 output. |
+| TLS | Service-to-service and RPC endpoints | Standard TLS. Configuration is per deployment. |
+| Key custody | Remote signing through [Web3Signer](../../protocol/architecture/index.mdx#web3signer), with optional AWS KMS-backed secp256k1 signing | AWS KMS uses FIPS 140-2 and FIPS 140-3 validated HSMs (validations held by AWS). Key custody is a deployment choice. |
+
+All signing and hashing go through established libraries (Besu, web3j, Tuweni,
+BouncyCastle) or AWS KMS. The stack does not implement custom cryptographic primitives.
+
 ## Available evidence
 
 The following public materials are the available assurance evidence for the Lineth stack:


### PR DESCRIPTION
Adds a "Cryptographic primitives" section to docs/stack/evaluate/security.mdx. The section lists the cryptographic primitives the Lineth stack relies on (secp256k1, secp256r1 via the P256VERIFY precompile, Keccak-256, TLS, and signing key custody) and flags the published standard for each where one applies, with canonical links to RIP-7212, FIPS 186-5, and FIPS 202.

The section is descriptive only. It makes no compliance, alignment, or certification claims.

Verified: npm run build passes (no broken links). No other files changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, configuration, or security logic impact.
> 
> **Overview**
> Adds a **Cryptographic primitives** section on the stack security evaluation page, placed before **Available evidence**. It documents what crypto Lineth uses in a three-column table: primitive, stack usage, and applicable standard or note.
> 
> The table covers secp256k1 signing, P-256 via `P256VERIFY` (with RIP-7212 and FIPS 186-5 links), Keccak-256 (including the Ethereum vs FIPS SHA3-256 distinction), TLS, and key custody via Web3Signer and optional AWS KMS (FIPS 140-2/140-3). The text is descriptive only and does not assert compliance or certification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7e2f880137259bca2f1f37437f2956498716b41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->