### PR TITLE
chore: add Prettier auto-formatting for docs and wire up husky

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,10 +15,20 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Lint code
-        uses: Consensys/github-actions/docs-lint-all@3a2429772a5d3653f0662a6a66299cad96e74196 # main
+        uses: Consensys/github-actions/docs-lint-all@main
 
-      - name: Lint markdown
-        uses: Consensys/github-actions/docs-lint-markdown@3a2429772a5d3653f0662a6a66299cad96e74196 # main
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v45
+        with:
+          files: |
+            **/*.{md,mdx,json,ts,js,tsx,jsx,css}
+
+      - name: Prettier check
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: npx prettier --check ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/.prettierrc
+++ b/.prettierrc
@@ -7,5 +7,14 @@
   "singleQuote": false,
   "trailingComma": "all",
   "tabWidth": 2,
-  "semi": true
+  "semi": true,
+  "overrides": [
+    {
+      "files": ["*.md", "*.mdx"],
+      "options": {
+        "printWidth": 120,
+        "proseWrap": "preserve"
+      }
+    }
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,6 +73,7 @@
         "globals": "17.7.0",
         "google-auth-library": "10.7.0",
         "googleapis-common": "8.0.2",
+        "husky": "^9.1.7",
         "lint-staged": "17.0.8",
         "prettier": "3.8.4",
         "semantic-release": "25.0.5",
@@ -19217,6 +19218,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/hyperdyperid": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "typecheck": "tsc",
     "typecheck-staged": "tsc-files --noEmit",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "write-translations": "docusaurus write-translations"
+    "write-translations": "docusaurus write-translations",
+    "prepare": "husky"
   },
   "commitlint": {
     "extends": [
@@ -37,7 +38,7 @@
     "src/**/*.{ts,js,jsx,tsx}": "npm run lint:js:fix",
     "**/*.{ts,tsx}": "npm run typecheck-staged",
     "**/*.css": "npm run lint:style",
-    "**/*.{md,mdx,ts,js,tsx,jsx,json}": "npm run format"
+    "**/*.{md,mdx,ts,js,tsx,jsx,json}": "prettier --write"
   },
   "browserslist": {
     "production": [
@@ -118,6 +119,7 @@
     "globals": "17.7.0",
     "google-auth-library": "10.7.0",
     "googleapis-common": "8.0.2",
+    "husky": "^9.1.7",
     "lint-staged": "17.0.8",
     "prettier": "3.8.4",
     "semantic-release": "25.0.5",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Tooling and CI-only changes with no runtime or security-sensitive application logic; CI action refs move from pinned commits to version tags.
> 
> **Overview**
> Adds **local auto-formatting on commit** via Husky (`prepare` + `.husky/pre-commit` → `lint-staged`) and runs **`prettier --write`** on staged markdown/code instead of the scoped `npm run format` script.
> 
> **Prettier** now uses **md/mdx overrides** (wider `printWidth`, `proseWrap: preserve`) so docs keep readable line breaks.
> 
> **CI lint** drops the separate `docs-lint-markdown` action and instead **checks Prettier only on changed** `md`, `mdx`, `json`, TS/JS, and CSS files (`tj-actions/changed-files` + `prettier --check`). Checkout moves to **`actions/checkout@v4`** with **`fetch-depth: 0`** so change detection works; Consensys lint actions use **`@main`** refs instead of pinned SHAs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07dd21d8f53253f6104bc435556840c414a9a476. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->