### PR TITLE
Update Ethereum differences page for Fusaka

### DIFF
--- a/docs/network/overview/ethereum-differences.mdx
+++ b/docs/network/overview/ethereum-differences.mdx
@@ -16,7 +16,7 @@ behavior on Ethereum Mainnet; if you're experiencing otherwise, please contact u
 
 :::note 
 
-With Linea [Beta v4](../../changelog/release-notes.mdx#beta-v40), Linea upgraded to the Pectra hard fork.
+With Linea [Beta v4.4](../../changelog/release-notes.mdx#beta-v44), Linea upgraded to the Fusaka hard fork.
 
 :::
 
@@ -76,28 +76,15 @@ for more._
     <th>Linea</th>
   </tr>
   <tr>
-    <td>`BLAKE2f`</td>
-    <td>
-      Compression function F used in the BLAKE2 cryptographic hashing algorithm.
-    </td>
-    <td>Not supported.</td>
-  </tr>
-  <tr>
     <td>`MODEXP`</td>
     <td>Arbitrary-precision exponentiation under modulo.</td>
     <td>Only supports arguments (base, exponent, modulus) that do not exceed
-      512-byte integers.</td>
+      1024-byte integers.</td>
   </tr>
   <tr>
     <td>Precompiles as transaction recipients</td>
     <td>Applicable to various use cases.</td>
-    <td>Not supported. A transaction `to` address cannot be a precompile, i.e. an
-      address in the range `0x01`-`0x09`.</td>
-  </tr>
-  <tr>
-    <td>`RIPEMD-160`</td>
-    <td>A hash function.</td>
-    <td>Not supported.</td>
+    <td>Not supported. A transaction `to` address cannot be a precompile.</td>
   </tr>
 </table>
 
@@ -107,7 +94,7 @@ for more._
 introduced a smart contract that enables the caller to `get` or `set` the hash tree root of a 
 beacon chain block.
 
-This functionality is available with Linea Beta v4. However, due to the difference in block time
+This functionality is available on Linea. However, due to the difference in block time
 when compared to Ethereum Mainnet, only the root of the previous block is available.
 
 ## Call data


### PR DESCRIPTION
## Summary

Brings `network/overview/ethereum-differences` up to date with Fusaka (Beta v4.4, live on Mainnet 3 December 2025) and the Osaka EVM:

- The hard fork note now references Fusaka / Beta v4.4 instead of Pectra / Beta v4.
- `BLAKE2f` and `RIPEMD-160` rows removed from the precompiles table: both are supported since Osaka (Besu `populateForOsaka` registers them; the zkEVM tracer has full Blake2f and RIPEMD handling).
- `MODEXP` argument bound updated from 512 to 1024 bytes (EIP-7823, enforced as `EIP_7823_MODEXP_UPPER_BYTE_SIZE_BOUND`).
- Precompile-as-recipient restriction no longer names the `0x01`–`0x09` range; the Osaka precompile set is larger (adds KZG, BLS12, P256 at `0x100`). The restriction itself is unchanged.
- Beacon root section: replaced the dated "available with Linea Beta v4" phrasing.

EVM opcode table, call data limit, type 3 transactions, JSON-RPC section, and EIP-7702 section were audited against the stack and need no changes.

## Verification

Claims verified against lineth-monorepo (origin/main) on both the tracer side (`AddressUtils.precompileAddressOsaka`, `oob_prc.zkasm`, `constants.lisp`) and the execution side (Besu 26.8.0 `MainnetPrecompiledContracts.populateForOsaka`). `npx docusaurus build` passes.