### PR TITLE
ci: point GitHub Actions at Consensys-Incorporated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,4 +25,4 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Build docs
-        uses: Consensys/github-actions/docs-build@3a2429772a5d3653f0662a6a66299cad96e74196 # main
+        uses: Consensys-Incorporated/github-actions/docs-build@3a2429772a5d3653f0662a6a66299cad96e74196 # main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,4 +25,4 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Build docs
-        uses: Consensys-Incorporated/github-actions/docs-build@3a2429772a5d3653f0662a6a66299cad96e74196 # main
+        uses: Consensys-Incorporated/github-actions/docs-build@28327992dc4f4eeeee937abbaebf63f00f4f6068 # main

--- a/.github/workflows/case.yml
+++ b/.github/workflows/case.yml
@@ -22,6 +22,6 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Case check action
-        uses: Consensys/github-actions/docs-case-check@3a2429772a5d3653f0662a6a66299cad96e74196 # main
+        uses: Consensys-Incorporated/github-actions/docs-case-check@3a2429772a5d3653f0662a6a66299cad96e74196 # main
         with:
           DOC_DIR: ${{ matrix.folder }}

--- a/.github/workflows/case.yml
+++ b/.github/workflows/case.yml
@@ -22,6 +22,6 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Case check action
-        uses: Consensys-Incorporated/github-actions/docs-case-check@3a2429772a5d3653f0662a6a66299cad96e74196 # main
+        uses: Consensys-Incorporated/github-actions/docs-case-check@28327992dc4f4eeeee937abbaebf63f00f4f6068 # main
         with:
           DOC_DIR: ${{ matrix.folder }}

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -18,6 +18,6 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: LinkCheck
-        uses: Consensys/github-actions/docs-link-check@3a2429772a5d3653f0662a6a66299cad96e74196 # main
+        uses: Consensys-Incorporated/github-actions/docs-link-check@3a2429772a5d3653f0662a6a66299cad96e74196 # main
         with:
           CONFIG_FILE: '.linkspector.yml'

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -18,6 +18,6 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: LinkCheck
-        uses: Consensys-Incorporated/github-actions/docs-link-check@3a2429772a5d3653f0662a6a66299cad96e74196 # main
+        uses: Consensys-Incorporated/github-actions/docs-link-check@28327992dc4f4eeeee937abbaebf63f00f4f6068 # main
         with:
           CONFIG_FILE: '.linkspector.yml'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Lint code
-        uses: Consensys/github-actions/docs-lint-all@3a2429772a5d3653f0662a6a66299cad96e74196 # main
+        uses: Consensys-Incorporated/github-actions/docs-lint-all@3a2429772a5d3653f0662a6a66299cad96e74196 # main
 
       - name: Lint markdown
-        uses: Consensys/github-actions/docs-lint-markdown@3a2429772a5d3653f0662a6a66299cad96e74196 # main
+        uses: Consensys-Incorporated/github-actions/docs-lint-markdown@3a2429772a5d3653f0662a6a66299cad96e74196 # main

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Lint code
-        uses: Consensys-Incorporated/github-actions/docs-lint-all@3a2429772a5d3653f0662a6a66299cad96e74196 # main
+        uses: Consensys-Incorporated/github-actions/docs-lint-all@28327992dc4f4eeeee937abbaebf63f00f4f6068 # main
 
       - name: Lint markdown
-        uses: Consensys-Incorporated/github-actions/docs-lint-markdown@3a2429772a5d3653f0662a6a66299cad96e74196 # main
+        uses: Consensys-Incorporated/github-actions/docs-lint-markdown@28327992dc4f4eeeee937abbaebf63f00f4f6068 # main

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: LinkCheck
-        uses: Consensys/github-actions/docs-link-check@3a2429772a5d3653f0662a6a66299cad96e74196 # main
+        uses: Consensys-Incorporated/github-actions/docs-link-check@3a2429772a5d3653f0662a6a66299cad96e74196 # main
         with:
           CONFIG_FILE: .linkspector.yml
 
@@ -30,7 +30,7 @@ jobs:
     permissions: {}   # zero scopes
     steps:
       - name: Slack Notification
-        uses: Consensys/github-actions/slack-notify@3a2429772a5d3653f0662a6a66299cad96e74196 # main
+        uses: Consensys-Incorporated/github-actions/slack-notify@3a2429772a5d3653f0662a6a66299cad96e74196 # main
         with:
           SLACK_CHANNEL: doc-ci-alerts
           SLACK_COLOR: danger

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: LinkCheck
-        uses: Consensys-Incorporated/github-actions/docs-link-check@3a2429772a5d3653f0662a6a66299cad96e74196 # main
+        uses: Consensys-Incorporated/github-actions/docs-link-check@28327992dc4f4eeeee937abbaebf63f00f4f6068 # main
         with:
           CONFIG_FILE: .linkspector.yml
 
@@ -30,7 +30,7 @@ jobs:
     permissions: {}   # zero scopes
     steps:
       - name: Slack Notification
-        uses: Consensys-Incorporated/github-actions/slack-notify@3a2429772a5d3653f0662a6a66299cad96e74196 # main
+        uses: Consensys-Incorporated/github-actions/slack-notify@28327992dc4f4eeeee937abbaebf63f00f4f6068 # main
         with:
           SLACK_CHANNEL: doc-ci-alerts
           SLACK_COLOR: danger

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -18,4 +18,4 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Vale
-        uses: Consensys/github-actions/docs-spelling-check@3a2429772a5d3653f0662a6a66299cad96e74196 # main
+        uses: Consensys-Incorporated/github-actions/docs-spelling-check@3a2429772a5d3653f0662a6a66299cad96e74196 # main

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -18,4 +18,4 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Vale
-        uses: Consensys-Incorporated/github-actions/docs-spelling-check@3a2429772a5d3653f0662a6a66299cad96e74196 # main
+        uses: Consensys-Incorporated/github-actions/docs-spelling-check@28327992dc4f4eeeee937abbaebf63f00f4f6068 # main


### PR DESCRIPTION
The shared docs actions repo moved off Consensys, so CI was failing to resolve Consensys/github-actions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only reference updates with no application or runtime code changes; main risk is mis-pinned SHA or org access blocking workflows.
> 
> **Overview**
> **Updates composite action sources** so docs CI can resolve shared workflows again after the actions repo moved from `Consensys/github-actions` to **`Consensys-Incorporated/github-actions`**.
> 
> Every affected workflow (`build`, `case`, `links`, `lint`, `spelling`, and `nightly`) now pins the same new commit (`28327992…`) on the relocated repo for steps such as docs build, case check, link check, lint, spelling (Vale), and nightly Slack notify—behavior and `with:` inputs are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0371dcd26ad6383147a214747254489244dc2533. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->